### PR TITLE
Fix nl toc links to WDC doc site

### DIFF
--- a/nl/de/toc
+++ b/nl/de/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [Erweiterte Dokumente](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [Erweiterte Dokumente (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/es/toc
+++ b/nl/es/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [Documentación ampliada](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [Documentación ampliada (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/fr/toc
+++ b/nl/fr/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [Documentation étendue](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [Documentation étendue (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/it/toc
+++ b/nl/it/toc
@@ -16,7 +16,7 @@ Comprensione del linguaggio naturale
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [Documenti estesi](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [Documenti estesi (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/ja/toc
+++ b/nl/ja/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [拡張資料](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [拡張資料 (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/ko/toc
+++ b/nl/ko/toc
@@ -16,7 +16,7 @@
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [확장된 문서](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [확장된 문서 (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/pt/BR/toc
+++ b/nl/pt/BR/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [Docs expandidos](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [Docs expandidos (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/zh/CN/toc
+++ b/nl/zh/CN/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [展开的文档](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [展开的文档 (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}

--- a/nl/zh/TW/toc
+++ b/nl/zh/TW/toc
@@ -16,7 +16,7 @@ Natural Language Understanding
     {: .navgroup-end}
 
     {: .navgroup id="howto"}
-    [展開的文件](https://www.ibm.com/watson/developercloud/doc/natural-language-understanding/index.html)
+    [展開的文件 (English)](https://console.bluemix.net/docs/services/natural-language-understanding/index.html?locale=en)
     {: .navgroup-end}
 
     {: .navgroup id="reference"}


### PR DESCRIPTION
- Now that the NLU doc is building on prod, instead of letting the English NLU doc that's not translated redirect to Bluemix prod, I changed the link to the expanded doc

- Fixes https://github.ibm.com/Watson/developer-experience/issues/3288