### PR TITLE
Fix typo with physics

### DIFF
--- a/categories.md
+++ b/categories.md
@@ -667,7 +667,7 @@ The following table shows the categories that are returned by the {{site.data.ke
 | science                   | medicine                               | surgery                                |                                |                               |
 | science                   | medicine                               | veterinary medicine                    |                                |                               |
 | science                   | medicine                               |                                        |                                |                               |
-| science                   | phyiscs                                | atomic physics                         |                                |                               |
+| science                   | physics                                | atomic physics                         |                                |                               |
 | science                   | physics                                | astrophysics                           |                                |                               |
 | science                   | physics                                | electromagnetism                       |                                |                               |
 | science                   | physics                                | hydraulics                             |                                |                               |

--- a/categories.md
+++ b/categories.md
@@ -558,7 +558,7 @@ The following table shows the categories that are returned by the {{site.data.ke
 | law, govt and politics    | legal issues                           | civil law                              | copyright                      |                               |
 | law, govt and politics    | legal issues                           | civil law                              |                                |                               |
 | law, govt and politics    | legal issues                           | civil rights                           |                                |                               |
-| law, govt and politics    | legal issues                           | civl rights                            | privacy                        |                               |
+| law, govt and politics    | legal issues                           | civil rights                           | privacy                        |                               |
 | law, govt and politics    | legal issues                           | criminal law                           |                                |                               |
 | law, govt and politics    | legal issues                           | death penalty                          |                                |                               |
 | law, govt and politics    | legal issues                           | human rights                           |                                |                               |


### PR DESCRIPTION
I just want to make sure this typo isn't a regression of the API. It used to be misspelled but was fixed late August or September.

Changes:
`phsyics` -> `physics`

Going forward it would be helpful if along with the `label` in the response from the NLU API there was an `id` that mapped to each leaf in this structure so that as the the `label` consumers would have a guaranteed unchanging entity. This with stricter versioning and release notes would be very helpful.  My company would sporadically get errors as the NLU API results change without notice or our decision to upgrade and we're left scratching our heads to determine what's changed or if there are errors in our code.